### PR TITLE
Add invalid.illegal.ini pattern to ini.tmLanguage.json

### DIFF
--- a/syntaxes/ini.tmLanguage.json
+++ b/syntaxes/ini.tmLanguage.json
@@ -7,6 +7,10 @@
 		},
 		{
 			"include": "#class"
+		},
+		{
+			"match": "(^[ \\t]*)?\\b([Ee]nd|END)\\b",
+			"name": "invalid.illegal.ini"
 		}
 	],
 	"repository": {


### PR DESCRIPTION
Now captures lonely end statements and marks them as illegal characters. 