### PR TITLE
fix: Generic vscode completion fix

### DIFF
--- a/syntaxes/ini.tmLanguage.json
+++ b/syntaxes/ini.tmLanguage.json
@@ -3787,7 +3787,7 @@
 				},
 				{
 					"match": "[a-zA-Z_:\\.+][\\w\\\\]*",
-					"name": "string.unquoted.ini"
+					"name": "property.ini"
 				}
 			]
 		},


### PR DESCRIPTION
Fixed issue where built in vscode completion handler stopped providing completions based on the document. 

Fixes #56 